### PR TITLE
Fix for inconsistent luminance units

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class AqaraHubLux {
         } else {
             const illuminance = await this.callForIlluminance();
             this.log.info('Current lux:', illuminance.value);
-            callback(null, illuminance.value)
+            callback(null, illuminance.value);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class AqaraHubLux {
         } else {
             const illuminance = await this.callForIlluminance();
             this.log.info('Current lux:', illuminance.value);
-            callback(null, illuminance.value;)
+            callback(null, illuminance.value)
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class AqaraHubLux {
         this.token = config.token;
         this.name = config.name ? config.name : 'Aqara Hub Lux';
         this.interval = config.interval ? config.interval * 1000 : 60000;
+        this.unitFactor = config.unitFactor ? config.unitFactor : 0.1;
         this.device = {};
 
         if (!this.ip) {
@@ -53,7 +54,7 @@ class AqaraHubLux {
         } else {
             const illuminance = await this.callForIlluminance();
             this.log.info('Current lux:', illuminance.value);
-            callback(null, illuminance.value);
+            callback(null, illuminance.value;)
         }
     }
 
@@ -65,9 +66,11 @@ class AqaraHubLux {
     async callForIlluminance() {
         this.log.debug('Try to call for illuminance...');
         try {
-            let illumimance = await this.device.miioCall('get_device_prop', ["lumi.0", "illumination"]);
-            this.log.debug('Check lux:', illumimance[0]);
-            return { value: illumimance[0] };
+            let illuminance = await this.device.miioCall('get_device_prop', ["lumi.0", "illumination"]);
+            this.log.debug('Check lux:', illuminance[0]);
+            illuminance[0] = illuminance[0] * this.unitFactor;
+            this.log.debug('Calculate lux:', illuminance[0]);
+            return { value: illuminance[0] };
         } catch (error) {
             this.log.error(error);
         }        


### PR DESCRIPTION
Dodatkowa opcja konfiguracji - unitFactor - to współczynnik przez który mnożone są wszelkie odczyty z sensora. Jego domyślna wartość to 0.1. Nie widzę co prawda nigdzie w aplikacjach Xiaomi i Aqary odczytów z sensora, ale posiadam dwa sensory światła Xiaomi na zigbee 3.0 podpięte natywnie (!) do HomeKita przez nową bramę Xiaomi i na podstawie bardzo luźnych obserwacji stwierdzam, że wartości zwracane przez plugin są ok. 10x większe niż odczyty przez sensory natywne, czyli są w hmm.. decyluxach ;) Przesuwamy przecinek stąd 0.1. Przyjąłbym to za wartość domyślną - aby zachować spójność pomiędzy urządzeniami z ekosystemu Xiaomi w projektowaniu automatyzacji opartych na odczytach przez sensory natywne i przez wtyczke, bo to chyba właściwy punkt odniesienia. 
Możliwość ręcznej konfiguracji współczynnika przyda się gdy ktoś korzysta z innych sensorów - mam np. bramę i 2 sensory z funkcją pomiaru światła od LifeSmart, też natywnie pod HK, i tam liczby są bodaj 100 czy 1000 razy większe niż te od Xiaomi, choć w obu przypadkach mówimy niby o tych samych „luksach” (a tak naprawdę są po prostu dokładniejsze...). Zatem w świecie light sensorów luks luksowi nierówny i fajnie byłoby móc sobie to dostosowywać pod to co się już posiada.
PS na świetle się nie znam, nie wiem które luxy są tymi prawdziwymi ale dla sprawy nie ma to znaczenia ;)